### PR TITLE
Fix country names branch

### DIFF
--- a/transmonee_dashboard/src/transmonee_dashboard/dev_cli.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/dev_cli.py
@@ -26,7 +26,7 @@ from transmonee_dashboard.app import app
 )
 @click.option(
     "--debug/--no-debug",
-    default=True,
+    default=False,
     help="Toggles whether the Dash app is run in debug mode. Defaults to True",
 )
 def main(port, host, debug):

--- a/transmonee_dashboard/src/transmonee_dashboard/index.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/index.py
@@ -29,18 +29,27 @@ nav_items = (
         html.Div(
             [
                 fa("fas fa-child"),
-                "Family environment and protection from violence and harmful practices",
+                "Family environment and protection",
             ]
         ),
     ),
     ("child-health", html.Div([fa("fas fa-heartbeat"), "Health and Nutrition"])),
     (
         "child-poverty",
-        html.Div(
-            [fa("fas fa-hand-holding-usd"), "Poverty and adequate standards of living"]
-        ),
+        html.Div([fa("fas fa-hand-holding-usd"), "Poverty"]),
     ),
 )
+
+nav_items_full_names = {
+    "education": "Education",
+    "child-protection": "Family environment and protection from violence and harmful practices",
+    "child-health": "Health and Nutrition",
+    "child-poverty": "Poverty and adequate standards of living",
+    "child-rights": "Child Rights Landscape",
+    "participation": "Participation",
+    "": "",
+    "": "",
+}
 
 router = DashRouter(app, urls)
 navbar = DashNavBar(app, nav_items)

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/__init__.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/__init__.py
@@ -367,6 +367,8 @@ years = list(range(2010, 2021))
 # define the function that will return the values of the selected countries from the dictionary
 countries_dict_filter = lambda x, y: dict([(i, x[i]) for i in x if i in set(y)])
 
+# a key:value dictionary of countries where the 'key' is the country name as displayed in the selection
+# tree whereas the 'value' is the country name as returned by the sdmx list: https://sdmx.data.unicef.org/ws/public/sdmxapi/rest/codelist/UNICEF/CL_COUNTRY/1.0
 countries_dict = {
     "Albania": "Albania",
     "Andorra": "Andorra",

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/__init__.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/__init__.py
@@ -364,6 +364,67 @@ codes = [
 
 years = list(range(2010, 2021))
 
+# define the function that will return the values of the selected countries from the dictionary
+countries_dict_filter = lambda x, y: dict([(i, x[i]) for i in x if i in set(y)])
+
+countries_dict = {
+    "Albania": "Albania",
+    "Andorra": "Andorra",
+    "Armenia": "Armenia",
+    "Austria": "Austria",
+    "Azerbaijan": "Azerbaijan",
+    "Belarus": "Belarus",
+    "Belgium": "Belgium",
+    "Bosnia and Herzegovina": "Bosnia and Herzegovina",
+    "Bulgaria": "Bulgaria",
+    "Croatia": "Croatia",
+    "Cyprus": "Cyprus",
+    "Czech Republic": "Czechia",  # we have this one is different
+    "Denmark": "Denmark",
+    "Estonia": "Estonia",
+    "Finland": "Finland",
+    "France": "France",
+    "Georgia": "Georgia",
+    "Germany": "Germany",
+    "Greece": "Greece",
+    "Holy See": "Holy See",
+    "Hungary": "Hungary",
+    "Iceland": "Iceland",
+    "Ireland": "Ireland",
+    "Italy": "Italy",
+    "Kazakhstan": "Kazakhstan",
+    "Kosovo (UN SC resolution 1244)": "Kosovo",  # we have this one is different
+    "Kyrgyzstan": "Kyrgyzstan",
+    "Latvia": "Latvia",
+    "Liechtenstein": "Liechtenstein",
+    "Lithuania": "Lithuania",
+    "Luxembourg": "Luxembourg",
+    "Malta": "Malta",
+    "Monaco": "Monaco",
+    "Montenegro": "Montenegro",
+    "Netherlands": "Netherlands",
+    "North Macedonia": "North Macedonia",
+    "Norway": "Norway",
+    "Poland": "Poland",
+    "Portugal": "Portugal",
+    "Romania": "Romania",
+    "Republic of Moldova": "Republic of Moldova",
+    "Russian Federation": "Russian Federation",
+    "San Marino": "San Marino",
+    "Serbia": "Serbia",
+    "Slovakia": "Slovakia",
+    "Slovenia": "Slovenia",
+    "Spain": "Spain",
+    "Sweden": "Sweden",
+    "Switzerland": "Switzerland",
+    "Tajikistan": "Tajikistan",
+    "Turkey": "Turkey",
+    "Turkmenistan": "Turkmenistan",
+    "Ukraine": "Ukraine",
+    "United Kingdom": "United Kingdom",
+    "Uzbekistan": "Uzbekistan",
+}
+
 countries = [
     "Albania",
     "Andorra",
@@ -376,7 +437,7 @@ countries = [
     "Bulgaria",
     "Croatia",
     "Cyprus",
-    "Czech Republic",
+    "Czech Republic",  # Czechia
     "Denmark",
     "Estonia",
     "Finland",
@@ -390,22 +451,22 @@ countries = [
     "Ireland",
     "Italy",
     "Kazakhstan",
-    "Kosovo (UN SC resolution 1244)",
+    "Kosovo (UN SC resolution 1244)",  # Kosovo
     "Kyrgyzstan",
     "Latvia",
     "Liechtenstein",
     "Lithuania",
     "Luxembourg",
     "Malta",
-    "Moldova",
     "Monaco",
+    "Montenegro",
     "Netherlands",
     "North Macedonia",
     "Norway",
     "Poland",
     "Portugal",
-    "Republic of Montenegro",
     "Romania",
+    "Republic of Moldova",
     "Russian Federation",
     "San Marino",
     "Serbia",
@@ -434,7 +495,7 @@ unicef_country_prog = [
     "Greece",
     "Kazakhstan",
     "Kyrgyzstan",
-    "Kosovo (UN SC resolution 1244)",
+    "Kosovo (UN SC resolution 1244)",  # Kosovo
     "Montenegro",
     "North Macedonia",
     "Republic of Moldova",
@@ -495,7 +556,7 @@ country_selections = [
             "Austria",
             "Belgium",
             "Cyprus",
-            "Czechia",
+            "Czech Republic",
             "Denmark",
             "Estonia",
             "Finland",
@@ -563,7 +624,7 @@ country_selections = [
                     "Bulgaria",
                     "Croatia",
                     "Cyprus",
-                    "Czechia",
+                    "Czech Republic",
                     "Denmark",
                     "Estonia",
                     "Finland",
@@ -693,16 +754,20 @@ except urllib.error.HTTPError as e:
 sdmx.rename(columns={"INDICATOR": "CODE"}, inplace=True)
 data = data.append(sdmx)
 
+# Replace the list of countries by the list of dictionary countries values
 # TODO: Replace to static list
 data = data.merge(
     right=pd.DataFrame(
-        [dict(country=country, **geocode_address(country)) for country in countries]
+        [
+            dict(country=country, **geocode_address(country))
+            for country in countries_dict.values()
+        ]
     ),
     left_on="Geographic area",
     right_on="country",
 )
 
-# check and drop non-numeric observations, eg: SDMX accepts >95 as an OBS_VALUE
+# check and drop non-numeric observations, eg: SDMX accepts > 95 as an OBS_VALUE
 filter_non_num = pd.to_numeric(data.OBS_VALUE, errors="coerce").isnull()
 if filter_non_num.any():
     not_num_code_val = data[["CODE", "OBS_VALUE"]][filter_non_num]

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -755,6 +755,19 @@ def set_default_values(theme, indicators_dict):
     ]
 
 
+@app.callback(
+    Output("area_2_types", "value"),
+    [
+        Input("store", "data"),
+    ],
+    [State("indicators", "data")],
+)
+def set_default_chart_types(theme, indicators_dict):
+    # set the default chart type value for area 2 as by default nothing is selected and the chart is displayed by default
+    area = AREA_KEYS[2]
+    return indicators_dict[theme["theme"]][area].get("default_graph")
+
+
 # does this function assume dimension is a disaggregation?
 # should we call it only if dimension is a disaggregation?
 def get_disag_total(data, indicator, dimension, default_total="Total"):

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -471,10 +471,7 @@ def apply_filters(theme, years_slider, country_selector, programme_toggle, indic
 
     # Use the dictionary to return the values of the selected countries based on the SDMX codes
     countries_selected = countries_dict_filter(countries_dict, countries_selected)
-    print(
-        "Dictionary Selected Countries Values",
-        countries_selected.values(),
-    )
+
     # cache the data based on selected years and countries
     selections = dict(
         theme=theme[1:].upper() if theme else next(iter(indicators.keys())),
@@ -533,6 +530,7 @@ def indicator_card(
         )
         .agg({"OBS_VALUE": "sum", "DATA_SOURCE": "count"})
     ).reset_index()
+
     numerator_pairs = (
         indicator_values[indicator_values.DATA_SOURCE == len(numors)]
         .groupby("Geographic area", as_index=False)
@@ -908,7 +906,6 @@ def main_figure(indicator, selections, indicators_dict):
         .reset_index()
     )
 
-    # print("Sorted Data", df)
     options["labels"] = DEFAULT_LABELS.copy()
     options["labels"]["OBS_VALUE"] = name
     return px.scatter_mapbox(df, **options), source

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -40,6 +40,7 @@ from . import (
     countries_dict_filter,
     countries_dict,
 )
+from flask import current_app as server
 
 # set defaults
 pio.templates.default = "plotly_white"
@@ -74,8 +75,10 @@ def get_base_layout(**kwargs):
     url_hash = (
         kwargs.get("hash")
         if kwargs.get("hash")
-        else "#{}".format(next(iter(indicators_dict.values()))["NAME"].lower())
+        else "#{}".format((next(iter(indicators_dict.items())))[0].lower())
+        # else "#{}".format(next(iter(indicators_dict.values()))["NAME"].lower())
     )
+
     return html.Div(
         [
             dcc.Store(id="indicators", data=indicators_dict),
@@ -87,19 +90,6 @@ def get_base_layout(**kwargs):
                             dbc.Row(
                                 [
                                     dbc.ButtonGroup(
-                                        [
-                                            dbc.Button(
-                                                value["NAME"],
-                                                id=key,
-                                                color=colours[num],
-                                                className="theme mx-1",
-                                                href=f"#{key.lower()}",
-                                                # active=url_hash == f"#{key.lower()}",
-                                            )
-                                            for num, (key, value) in enumerate(
-                                                indicators_dict.items()
-                                            )
-                                        ],
                                         id="themes",
                                     ),
                                 ],
@@ -686,6 +676,30 @@ def show_cards(selections, current_cards, indicators_dict):
         for num, card in enumerate(indicators_dict[selections["theme"]]["CARDS"])
     ]
     return cards
+
+
+@app.callback(
+    Output("themes", "children"),
+    [
+        Input("store", "data"),
+    ],
+    [State("themes", "children"), State("indicators", "data")],
+)
+def show_themes(selections, current_themes, indicators_dict):
+    url_hash = "#{}".format((next(iter(selections.items())))[1].lower())
+
+    buttons = [
+        dbc.Button(
+            value["NAME"],
+            id=key,
+            color=colours[num],
+            className="theme mx-1",
+            href=f"#{key.lower()}",
+            active=url_hash == f"#{key.lower()}",
+        )
+        for num, (key, value) in enumerate(indicators_dict.items())
+    ]
+    return buttons
 
 
 @app.callback(

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -636,7 +636,9 @@ def indicator_card(
             dbc.Popover(
                 [
                     dbc.PopoverHeader(f"Sources: {indicator}"),
-                    dbc.PopoverBody(str(sources)),
+                    dbc.PopoverBody(
+                        dcc.Markdown(get_card_popover_body(sources))
+                    ),  # replace the tooltip with the desired bullet list layout
                 ],
                 id="hover",
                 target=card_id,
@@ -648,6 +650,18 @@ def indicator_card(
         id=card_id,
     )
     return card
+
+
+# this function is used to generate the list of countries that are part of the card's displayed result;
+# it displays the countries as a list, each on a separate line...
+def get_card_popover_body(sources):
+    card_countries = ""
+    for index, source_info in enumerate(sources):
+        if card_countries == "":
+            card_countries = f"- {source_info[0]}: {source_info[1]}"
+        else:
+            card_countries += f"\n- {source_info[0]}: {source_info[1]}"
+    return card_countries
 
 
 @app.callback(

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -628,7 +628,7 @@ def indicator_card(
                     dbc.PopoverHeader(f"Sources: {indicator}"),
                     dbc.PopoverBody(
                         dcc.Markdown(get_card_popover_body(sources))
-                    ),  # replace the tooltip with the desired bullet list layout
+                    ),  # replace the tooltip with the desired bullet list layout, was str(sources)
                 ],
                 id="hover",
                 target=card_id,

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -72,6 +72,7 @@ CARD_TEXT_STYLE = {"textAlign": "center", "color": "#0074D9"}
 def get_base_layout(**kwargs):
 
     indicators_dict = kwargs.get("indicators")
+    # I changed this to correctly read the hash as you were reading the name which is different
     url_hash = (
         kwargs.get("hash")
         if kwargs.get("hash")
@@ -466,7 +467,9 @@ def apply_filters(theme, years_slider, country_selector, programme_toggle, indic
     selections = dict(
         theme=theme[1:].upper() if theme else next(iter(indicators.keys())),
         years=selected_years,
-        countries=list(countries_selected.values()),
+        countries=list(
+            countries_selected.values()
+        ),  # use the values after the change done
     )
 
     get_filtered_dataset(**selections)
@@ -626,9 +629,7 @@ def indicator_card(
             dbc.Popover(
                 [
                     dbc.PopoverHeader(f"Sources: {indicator}"),
-                    dbc.PopoverBody(
-                        dcc.Markdown(get_card_popover_body(sources))
-                    ),  # replace the tooltip with the desired bullet list layout, was str(sources)
+                    dbc.PopoverBody(str(sources)),
                 ],
                 id="hover",
                 target=card_id,
@@ -640,18 +641,6 @@ def indicator_card(
         id=card_id,
     )
     return card
-
-
-# this function is used to generate the list of countries that are part of the card's displayed result;
-# it displays the countries as a list, each on a separate line...
-def get_card_popover_body(sources):
-    card_countries = ""
-    for index, source_info in enumerate(sources):
-        if card_countries == "":
-            card_countries = f"- {source_info[0]}: {source_info[1]}"
-        else:
-            card_countries += f"\n- {source_info[0]}: {source_info[1]}"
-    return card_countries
 
 
 @app.callback(
@@ -678,6 +667,7 @@ def show_cards(selections, current_cards, indicators_dict):
     return cards
 
 
+# Added this function to add the button group and set the correct active button
 @app.callback(
     Output("themes", "children"),
     [

--- a/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
+++ b/transmonee_dashboard/src/transmonee_dashboard/pages/base_page.py
@@ -37,6 +37,8 @@ from . import (
     countries,
     years,
     data,
+    countries_dict_filter,
+    countries_dict,
 )
 
 # set defaults
@@ -158,7 +160,7 @@ def get_base_layout(**kwargs):
                                                 ),
                                                 style={
                                                     "maxHeight": "250px",
-                                                    # "max-width": "300px",
+                                                    # "maxWidth": "300px",
                                                 },
                                                 className="overflow-auto",
                                                 body=True,
@@ -467,11 +469,17 @@ def apply_filters(theme, years_slider, country_selector, programme_toggle, indic
 
     selected_years = years[slice(*years_slider)]
 
+    # Use the dictionary to return the values of the selected countries based on the SDMX codes
+    countries_selected = countries_dict_filter(countries_dict, countries_selected)
+    print(
+        "Dictionary Selected Countries Values",
+        countries_selected.values(),
+    )
     # cache the data based on selected years and countries
     selections = dict(
         theme=theme[1:].upper() if theme else next(iter(indicators.keys())),
         years=selected_years,
-        countries=list(countries_selected),
+        countries=list(countries_selected.values()),
     )
 
     get_filtered_dataset(**selections)


### PR DESCRIPTION
In this PR, please review the following two things:

1- The country_dict added to the init.py page where I added a key-value dictionary for the country names as returned in this list: https://sdmx.data.unicef.org/ws/public/sdmxapi/rest/codelist/UNICEF/CL_COUNTRY/1.0 and the names we need to display in our dashboard. And used this dictionary for proper filtering of data. This change has affected mainly the init and the base_page.

2- The second change was the show_themes call back function added to set the active style of the button group for the themes. This can be improved as James said, but it is good to review the current solution.

Thank you.